### PR TITLE
Add enrollment search filter (and combine search histograms into one util)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2912,18 +2912,6 @@
       "integrity": "sha512-xKDpKLoSyxuTnbZ+fcsQRFRMbKSYqtg20Za2xtfWHCCotnpD4PKASPt3vbwPa1g5jGDPLGHsXw8DkRLschyq0w==",
       "license": "MIT"
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
-      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/jquery": {
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",

--- a/src/components/SearchBar/AdvancedSearch/PriceHistogram/index.tsx
+++ b/src/components/SearchBar/AdvancedSearch/PriceHistogram/index.tsx
@@ -1,17 +1,8 @@
 "use client";
 
-import { useId, useRef, useMemo } from "react";
-import * as Slider from "@radix-ui/react-slider";
-import { useResizeObserver } from "usehooks-ts";
-import get from "lodash/get";
-import { scaleLinear } from "d3-scale";
-import { max } from "d3-array";
-import { line } from "d3-shape";
 import { usePriceHistogram } from "@/hooks/usePriceHistogram";
 import type { IncomeBracketKey } from "@/types";
-import styles from "./styles.module.scss";
-
-const margin = { top: 1, right: 10, bottom: 1, left: 10 };
+import RangeHistogram from "../RangeHistogram";
 
 export default function PriceHistogram(props: {
   bracket?: IncomeBracketKey;
@@ -20,120 +11,19 @@ export default function PriceHistogram(props: {
   updateMinPrice: (price: number) => void;
   updateMaxPrice: (price: number) => void;
 }) {
-  const {
-    bracket = "average",
-  } = props;
-
+  const { bracket = "average" } = props;
   const { data: bracketBins } = usePriceHistogram();
-
-  const id = useId();
-
-  const ref = useRef<HTMLDivElement>(null);
-  const { width = 0 } = useResizeObserver({ ref: ref as React.RefObject<HTMLElement> });
-  const height = 60;
-
-  const {
-    x,
-    y,
-    path,
-  } = useMemo(() => {
-    const bins = bracketBins[bracket];
-
-    const binMax = get(bins, [bins.length - 1, "x1"], 1);
-    const x = scaleLinear()
-      .domain([0, binMax])
-      .range([margin.left, width - margin.right]);
-    const y = scaleLinear()
-      .domain([0, max(bins, (d) => d.length) || 1])
-      .range([height - margin.bottom, margin.top]);
-
-    const points = [[0, 0]];
-    bins.forEach((bin) => {
-      points.push([bin.x0!, bin.length]);
-      points.push([bin.x1!, bin.length]);
-    });
-    points.push([binMax, 0]);
-
-    const areaPath = line<number[]>()
-      .x((d) => x(d[0]))
-      .y((d) => y(d[1]));
-
-    return {
-      x,
-      y,
-      path: areaPath(points) || "",
-    };
-  }, [bracketBins, width, height, bracket]);
-
-  const maxPriceValue = props.maxPrice || x.domain()[1];
+  const bins = bracketBins[bracket];
 
   return (
-    <div
-      ref={ref}
-      className={styles.container}
-    >
-      <div className={styles.plot}>
-        <svg
-          className={styles.canvas}
-          width={width}
-          height={height}
-          viewBox={`0 0 ${width} ${height}`}
-        >
-          <defs>
-            <clipPath id={`clip-path-${id}`}>
-              <rect
-                x={x(props.minPrice)}
-                y={0}
-                width={x(maxPriceValue) - x(props.minPrice)}
-                height={height}
-              />
-            </clipPath>
-          </defs>
-          <path
-            d={path}
-            className={styles.bgArea}
-          />
-          <path
-            d={path}
-            className={styles.selectedArea}
-            clipPath={`url(#clip-path-${id})`}
-          />
-
-          <line
-            x1={x(props.minPrice)}
-            y1={y.range()[0]}
-            x2={x(props.minPrice)}
-            y2={y.range()[1]}
-            className={styles.minMaxLine}
-          />
-          <line
-            x1={x(maxPriceValue)}
-            y1={y.range()[0]}
-            x2={x(maxPriceValue)}
-            y2={y.range()[1]}
-            className={styles.minMaxLine}
-          />
-        </svg>
-
-        <div className={styles.inputs}>
-          <Slider.Root
-            className={styles.sliderRoot}
-            value={[props.minPrice, maxPriceValue]}
-            min={0}
-            max={x.domain()[1]}
-            onValueChange={([newMin, newMax]) => {
-              props.updateMinPrice(newMin);
-              props.updateMaxPrice(Math.max(newMin, newMax));
-            }}
-          >
-            <Slider.Track className={styles.sliderTrack}>
-              <Slider.Range className={styles.sliderRange} />
-            </Slider.Track>
-            <Slider.Thumb className={styles.sliderThumb} aria-label="Minimum price" />
-            <Slider.Thumb className={styles.sliderThumb} aria-label="Maximum price" />
-          </Slider.Root>
-        </div>
-      </div>
-    </div>
+    <RangeHistogram
+      bins={bins}
+      min={props.minPrice}
+      max={props.maxPrice}
+      onChangeMin={props.updateMinPrice}
+      onChangeMax={props.updateMaxPrice}
+      minLabel="Minimum price"
+      maxLabel="Maximum price"
+    />
   );
 }

--- a/src/components/SearchBar/AdvancedSearch/RangeHistogram/index.tsx
+++ b/src/components/SearchBar/AdvancedSearch/RangeHistogram/index.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useId, useRef, useMemo } from "react";
+import * as Slider from "@radix-ui/react-slider";
+import { useResizeObserver } from "usehooks-ts";
+import get from "lodash/get";
+import { scaleLinear } from "d3-scale";
+import { max } from "d3-array";
+import { line } from "d3-shape";
+import type { HistogramData } from "@/types";
+import styles from "./styles.module.scss";
+
+const margin = { top: 1, right: 10, bottom: 1, left: 10 };
+
+export default function RangeHistogram(props: {
+  bins: HistogramData[];
+  min: number;
+  max?: number;
+  onChangeMin: (value: number) => void;
+  onChangeMax: (value: number) => void;
+  minLabel: string;
+  maxLabel: string;
+}) {
+  const id = useId();
+
+  const ref = useRef<HTMLDivElement>(null);
+  const { width = 0 } = useResizeObserver({ ref: ref as React.RefObject<HTMLElement> });
+  const height = 60;
+
+  const {
+    x,
+    y,
+    path,
+  } = useMemo(() => {
+    const binMax = get(props.bins, [props.bins.length - 1, "x1"], 1);
+    const x = scaleLinear()
+      .domain([0, binMax])
+      .range([margin.left, width - margin.right]);
+    const y = scaleLinear()
+      .domain([0, max(props.bins, (d) => d.length) || 1])
+      .range([height - margin.bottom, margin.top]);
+
+    const points = [[0, 0]];
+    props.bins.forEach((bin) => {
+      points.push([bin.x0, bin.length]);
+      points.push([bin.x1, bin.length]);
+    });
+    points.push([binMax, 0]);
+
+    const areaPath = line<number[]>()
+      .x((d) => x(d[0]))
+      .y((d) => y(d[1]));
+
+    return {
+      x,
+      y,
+      path: areaPath(points) || "",
+    };
+  }, [props.bins, width, height]);
+
+  const maxValue = props.max || x.domain()[1];
+
+  return (
+    <div
+      ref={ref}
+      className={styles.container}
+    >
+      <div className={styles.plot}>
+        <svg
+          className={styles.canvas}
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+        >
+          <defs>
+            <clipPath id={`clip-path-${id}`}>
+              <rect
+                x={x(props.min)}
+                y={0}
+                width={x(maxValue) - x(props.min)}
+                height={height}
+              />
+            </clipPath>
+          </defs>
+          <path
+            d={path}
+            className={styles.bgArea}
+          />
+          <path
+            d={path}
+            className={styles.selectedArea}
+            clipPath={`url(#clip-path-${id})`}
+          />
+
+          <line
+            x1={x(props.min)}
+            y1={y.range()[0]}
+            x2={x(props.min)}
+            y2={y.range()[1]}
+            className={styles.minMaxLine}
+          />
+          <line
+            x1={x(maxValue)}
+            y1={y.range()[0]}
+            x2={x(maxValue)}
+            y2={y.range()[1]}
+            className={styles.minMaxLine}
+          />
+        </svg>
+
+        <div className={styles.inputs}>
+          <Slider.Root
+            className={styles.sliderRoot}
+            value={[props.min, maxValue]}
+            min={0}
+            max={x.domain()[1]}
+            onValueChange={([newMin, newMax]) => {
+              const sliderMax = x.domain()[1];
+              props.onChangeMin(newMin);
+              props.onChangeMax(newMax >= sliderMax ? 0 : Math.max(newMin, newMax));
+            }}
+          >
+            <Slider.Track className={styles.sliderTrack}>
+              <Slider.Range className={styles.sliderRange} />
+            </Slider.Track>
+            <Slider.Thumb className={styles.sliderThumb} aria-label={props.minLabel} />
+            <Slider.Thumb className={styles.sliderThumb} aria-label={props.maxLabel} />
+          </Slider.Root>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SearchBar/AdvancedSearch/RangeHistogram/styles.module.scss
+++ b/src/components/SearchBar/AdvancedSearch/RangeHistogram/styles.module.scss
@@ -64,7 +64,6 @@
 	height: 20px;
 	background-color: white;
   border: 1px solid colors.$bg-dark;
-	//box-shadow: 0 2px 10px rgba(black, 0.2);
 	border-radius: 10px;
   cursor: grab;
 }

--- a/src/components/SearchBar/AdvancedSearch/SizeHistogram/index.tsx
+++ b/src/components/SearchBar/AdvancedSearch/SizeHistogram/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useSizeHistogram } from "@/hooks/useSizeHistogram";
+import RangeHistogram from "../RangeHistogram";
+
+export default function SizeHistogram(props: {
+  minSize: number;
+  maxSize?: number;
+  updateMinSize: (size: number) => void;
+  updateMaxSize: (size: number) => void;
+}) {
+  const { data: { bins } } = useSizeHistogram();
+
+  return (
+    <RangeHistogram
+      bins={bins}
+      min={props.minSize}
+      max={props.maxSize}
+      onChangeMin={props.updateMinSize}
+      onChangeMax={props.updateMaxSize}
+      minLabel="Minimum enrollment"
+      maxLabel="Maximum enrollment"
+    />
+  );
+}

--- a/src/components/SearchBar/AdvancedSearch/index.tsx
+++ b/src/components/SearchBar/AdvancedSearch/index.tsx
@@ -7,6 +7,7 @@ import { useIncomeBracket } from "@/hooks/useIncomeBracket";
 import type { IncomeBracketKey } from "@/types";
 import type { SearchOptions, UpdateSearch } from "@/hooks/useSearchState";
 import PriceHistogram from "./PriceHistogram";
+import SizeHistogram from "./SizeHistogram";
 import styles from "./styles.module.scss";
 
 /**
@@ -149,7 +150,8 @@ export default function AdvancedSearch(props: {
               <label>
                 <input
                   type="number"
-                  value={search.minPrice}
+                  value={search.minPrice || ""}
+                  placeholder="No minimum"
                   onChange={(e) => updateSearch("minPrice", +e.target.value)}
                 />
                 <span>{content("SearchBar.advanced.cost.minimum")}</span>
@@ -159,9 +161,51 @@ export default function AdvancedSearch(props: {
                 <input
                   type="number"
                   value={search.maxPrice || ""}
+                  placeholder="No maximum"
                   onChange={(e) => updateSearch("maxPrice", +e.target.value)}
                 />
                 <span>{content("SearchBar.advanced.cost.maximum")}</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.sizeSection}>
+          <h3>{content("SearchBar.advanced.size.title")}</h3>
+
+          <p className={styles.instructions}>
+            {content("SearchBar.advanced.size.instructions")}
+          </p>
+
+          <div>
+            <div className={styles.sizeHistogram}>
+              <SizeHistogram
+                minSize={search.minSize}
+                maxSize={search.maxSize}
+                updateMinSize={(size: number) => updateSearch("minSize", size)}
+                updateMaxSize={(size: number) => updateSearch("maxSize", size)}
+              />
+            </div>
+
+            <div className={styles.size}>
+              <label>
+                <input
+                  type="number"
+                  value={search.minSize || ""}
+                  placeholder="No minimum"
+                  onChange={(e) => updateSearch("minSize", +e.target.value)}
+                />
+                <span>{content("SearchBar.advanced.size.minimum")}</span>
+              </label>
+
+              <label>
+                <input
+                  type="number"
+                  value={search.maxSize || ""}
+                  placeholder="No maximum"
+                  onChange={(e) => updateSearch("maxSize", +e.target.value)}
+                />
+                <span>{content("SearchBar.advanced.size.maximum")}</span>
               </label>
             </div>
           </div>

--- a/src/components/SearchBar/AdvancedSearch/styles.module.scss
+++ b/src/components/SearchBar/AdvancedSearch/styles.module.scss
@@ -17,6 +17,7 @@
 }
 
 .costSection,
+.sizeSection,
 .schoolTypeSection,
 .degreeTypeSection,
 .otherSection {
@@ -81,6 +82,33 @@
   margin: 18px 0 12px;
 }
 
+.sizeHistogram {
+  margin: 18px 0 12px;
+}
+
+.size {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  label {
+    justify-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: colors.$text-light;
+
+    &:last-child {
+      justify-self: flex-end;
+    }
+  }
+
+  input {
+    border: 1px solid colors.$border-main;
+    padding: 6px 8px;
+    text-align: center;
+  }
+}
+
 .cost {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -100,7 +128,7 @@
   input {
     border: 1px solid colors.$border-main;
     padding: 6px 8px;
-    text-align: right;
+    text-align: center;
   }
 }
 

--- a/src/components/SearchBar/MoreOptions/index.tsx
+++ b/src/components/SearchBar/MoreOptions/index.tsx
@@ -20,6 +20,8 @@ export default function MoreOptions(props: {
   const {
     minPrice = 0,
     maxPrice = 0,
+    minSize = 0,
+    maxSize = 0,
     schoolType = [],
     degreeType = "any",
     tribalCollege = false,
@@ -28,8 +30,15 @@ export default function MoreOptions(props: {
 
   const content = useContent();
 
+  const sizeText = (minSize !== 0 || !!maxSize)
+    ? maxSize
+      ? `${minSize.toLocaleString()}–${maxSize.toLocaleString()} students`
+      : `${minSize.toLocaleString()}+ students`
+    : "";
+
   const text = [
     (minPrice !== 0 || !!maxPrice) && `${formatDollars(minPrice)} to ${formatDollars(maxPrice)}`,
+    sizeText,
     schoolType.join(", "),
     (degreeType !== "any") ? degreeType : "",
     tribalCollege && "tribal college",

--- a/src/components/SearchResults/useFilteredSchools.ts
+++ b/src/components/SearchResults/useFilteredSchools.ts
@@ -37,6 +37,17 @@ const matchCost = (opts: {
   return true;
 };
 
+const matchSize = (opts: {
+  school: SchoolIndex;
+  minSize: number;
+  maxSize?: number;
+}) => {
+  const size = opts.school.enrollment;
+  if (size < opts.minSize) return false;
+  if (opts.maxSize && opts.maxSize < size) return false;
+  return true;
+};
+
 const matchSchoolType = (opts: {
   school: SchoolIndex;
   schoolType: SearchOptions["schoolType"];
@@ -87,6 +98,7 @@ export function useFilteredSchools(opts: {
       matchName({ school, name: search.where })
       && matchStates({ school, states: search.states })
       && matchCost({ school, bracket, minPrice: search.minPrice, maxPrice: search.maxPrice })
+      && matchSize({ school, minSize: search.minSize, maxSize: search.maxSize })
       && matchSchoolType({ school, schoolType: search.schoolType })
       && matchDegreeType({ school, degreeType: search.degreeType })
       && matchTribalCollege({ school, tribalCollege: search.tribalCollege })

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -1006,6 +1006,26 @@ export const contentSections = [
           },
           {
             type: "copy",
+            path: "SearchBar.advanced.size.title",
+            title: "Advanced enrollment title"
+          },
+          {
+            type: "copy",
+            path: "SearchBar.advanced.size.instructions",
+            title: "Advanced enrollment instructions"
+          },
+          {
+            type: "copy",
+            path: "SearchBar.advanced.size.minimum",
+            title: "Advanced enrollment minimum"
+          },
+          {
+            type: "copy",
+            path: "SearchBar.advanced.size.maximum",
+            title: "Advanced enrollment maximum"
+          },
+          {
+            type: "copy",
             path: "SearchBar.advanced.schoolType.title",
             title: "Advanced school type title"
           },

--- a/src/data/translations.csv
+++ b/src/data/translations.csv
@@ -35,6 +35,11 @@ SearchBar.advanced.cost.anyIncome,Any,Cualquiera
 SearchBar.advanced.cost.histogramTitle,Net price for,Precio neto
 SearchBar.advanced.cost.minimum,Minimum,Mínimo
 SearchBar.advanced.cost.maximum,Maximum,Máximo
+SearchBar.advanced.size.title,Size of school,Tamaño de la institución
+SearchBar.advanced.size.instructions,Use the slider to filter schools by enrollment size,Use el control deslizante para filtrar escuelas por tamaño de matrícula
+SearchBar.advanced.size.histogramTitle,Enrollment,Matrícula
+SearchBar.advanced.size.minimum,Minimum,Mínimo
+SearchBar.advanced.size.maximum,Maximum,Máximo
 SearchBar.advanced.schoolType.title,School type,Tipo de institución
 SearchBar.advanced.degreeType.title,Degree type,Tipo de diploma
 SearchBar.advanced.degreeType.anyType,Any type,Cualquier tipo

--- a/src/db/schools.ts
+++ b/src/db/schools.ts
@@ -487,7 +487,7 @@ export const getSizeHistogram = async (opts: {
     const binValues = sizes.map((s) => Math.min(s, upperLimit));
 
     const binner = bin()
-      .thresholds(100);
+      .thresholds(30);
 
     return {
       percentiles,

--- a/src/hooks/useSearchState.ts
+++ b/src/hooks/useSearchState.ts
@@ -14,6 +14,8 @@ const SearchSchema = z.object({
   states: z.array(z.string()).default([]),
   minPrice: z.number().default(0),
   maxPrice: z.number().optional(),
+  minSize: z.number().default(0),
+  maxSize: z.number().optional(),
   schoolType: z.array(z.enum(schoolTypes)).default([]),
   degreeType: z.enum(degreeTypes).default("any"),
   tribalCollege: z.boolean().default(false),


### PR DESCRIPTION
This adds the Enrollment filter, which re-uses a bunch of logic from the Price filter.

In fact, I just made a combined util for ALL histogram filters and called it a day! 

This also handles adding the necessary text fields to the back-end. 