### PR TITLE
Fix pipeline for Vercel + add IPEDS 2024 support

### DIFF
--- a/bin/bootstrap.ts
+++ b/bin/bootstrap.ts
@@ -426,9 +426,11 @@ const main = async () => {
     for (const school of [...stateSchools, ...liberalArtsSchools]) {
       console.log(`Fetching image for school ${school.id}...`);
       try {
-        const rsp = await fetch(school.imageUrl);
+        const rsp = await fetch(school.imageUrl, {
+          headers: { "User-Agent": "TuitionTracker/1.0 (https://tuitiontracker.org)" },
+        });
         if (!rsp.ok || !rsp.body) {
-          throw new Error(`Failed to download image for school ${school.id} from ${school.imageUrl}`);
+          throw new Error(`Failed to download image for school ${school.id} from ${school.imageUrl} (${rsp.status})`);
         }
         const blob = await put(`school-image-${school.id}`, rsp.body, {
           access: "public",
@@ -440,7 +442,7 @@ const main = async () => {
         });
       } catch (error) {
         console.error(error);
-        return null;
+        continue;
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@tanstack/react-query": "^5.80.3",
         "@types/google-publisher-tag": "^1.20250728.0",
         "@vercel/blob": "^1.1.1",
+        "@vercel/functions": "^3.4.3",
         "adm-zip": "^0.5.16",
         "cheerio": "^1.1.2",
         "clsx": "^2.1.1",
@@ -3578,6 +3579,35 @@
       },
       "engines": {
         "node": ">=16.14"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@xmldom/xmldom": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "^5.80.3",
     "@types/google-publisher-tag": "^1.20250728.0",
     "@vercel/blob": "^1.1.1",
+    "@vercel/functions": "^3.4.3",
     "adm-zip": "^0.5.16",
     "cheerio": "^1.1.2",
     "clsx": "^2.1.1",

--- a/src/admin/components/Field/index.tsx
+++ b/src/admin/components/Field/index.tsx
@@ -67,7 +67,7 @@ export default function Field(props: {
       <TextField
         id={field.path}
         label={field.title}
-        value={value}
+        value={value ?? ""}
         variant="outlined"
         onChange={(e) => onChange([field.path], e.target.value)}
         sx={{ flexGrow: 1 }}
@@ -81,7 +81,7 @@ export default function Field(props: {
         <TextField
           id={field.path}
           label={`${field.title} (${localeLabel})`}
-          value={value}
+          value={value ?? ""}
           variant="outlined"
           onChange={(e) => onChange([field.path, locale], e.target.value)}
         />
@@ -180,7 +180,7 @@ export default function Field(props: {
         <Select
           labelId={`select-${id}-label`}
           id={`select-${id}`}
-          value={value}
+          value={value ?? ""}
           label={field.title}
           onChange={(e) => onChange([field.path], e.target.value)}
         >

--- a/src/admin/components/PipelineDashboard/index.tsx
+++ b/src/admin/components/PipelineDashboard/index.tsx
@@ -4,16 +4,54 @@ import { useState, useCallback } from "react";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Container from "@mui/material/Container";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
 import Field from "@/admin/components/Field";
 import SubmitButton, { type SubmittingState } from "@/admin/components/SubmitButton";
 
+type FileStatus = {
+  file: string;
+  label: string;
+  available: boolean;
+};
+
 export default function PipelineDashboard() {
-  const [year, setYear] = useState<string>();
+  const [year, setYear] = useState<string>("");
+  const [checking, setChecking] = useState(false);
+  const [files, setFiles] = useState<FileStatus[] | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
+  const [pipelineStarted, setPipelineStarted] = useState<string | null>(null);
 
   const [submittingState, setSubmittingState] = useState<SubmittingState>({ state: "ready" });
 
-  const submitChanges = useCallback(async () => {
+  const checkFiles = useCallback(async () => {
     if (!year) return;
+
+    setChecking(true);
+    setFiles(null);
+    setCheckError(null);
+
+    try {
+      const rsp = await fetch(`/api/admin/check-ipeds-files?year=${year}`);
+      if (!rsp.ok) throw new Error("Failed to check files");
+      const data = await rsp.json();
+      setFiles(data.files);
+    } catch (error) {
+      setCheckError(`${error}`);
+    } finally {
+      setChecking(false);
+    }
+  }, [year]);
+
+  const allAvailable = files?.every((f) => f.available) ?? false;
+  const missingCount = files?.filter((f) => !f.available).length ?? 0;
+
+  const submitChanges = useCallback(async () => {
+    if (!year || !allAvailable) return;
 
     setSubmittingState({ state: "submitting" });
     try {
@@ -25,41 +63,115 @@ export default function PipelineDashboard() {
         throw new Error("Data pipeline failed");
       }
 
+      setPipelineStarted(year);
       setSubmittingState({ state: "success" });
-      setYear(undefined);
+      setYear("");
+      setFiles(null);
     } catch (error) {
       console.error(error);
       setSubmittingState({ state: "error", error: `${error}` });
     } finally {
       setTimeout(() => setSubmittingState({ state: "ready" }), 3000);
     }
-  }, [year]);
+  }, [year, allAvailable]);
 
   return (
     <Container maxWidth="md">
       <Stack spacing={4} sx={{ py: 4 }}>
-        <Paper
-          sx={{ p: 4 }}
-          elevation={1}
-        >
-          <Stack>
-            <Field
-              field={{
-                type: "string",
-                title: "Year",
-                path: "year",
-              }}
-              value={year || ""}
-              onChange={(_, value) => setYear(`${value}`)}
-            />
+        <Paper sx={{ p: 4 }} elevation={1}>
+          <Stack spacing={3}>
+            <Typography variant="h6">Run Data Pipeline</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Enter the IPEDS data year, then check file availability before
+              running the pipeline.
+            </Typography>
+
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              <Field
+                field={{
+                  type: "string",
+                  title: "Year",
+                  path: "year",
+                }}
+                value={year}
+                onChange={(_, value) => {
+                  setYear(`${value}`);
+                  setFiles(null);
+                  setCheckError(null);
+                }}
+              />
+              <Button
+                variant="contained"
+                onClick={checkFiles}
+                disabled={!year || checking}
+                sx={{ mt: "8px !important", whiteSpace: "nowrap" }}
+              >
+                {checking ? <CircularProgress size={24} /> : "Check Files"}
+              </Button>
+            </Stack>
+
+            {checkError && (
+              <Alert severity="error">{checkError}</Alert>
+            )}
           </Stack>
         </Paper>
+
+        {pipelineStarted && (
+          <Alert severity="info" onClose={() => setPipelineStarted(null)}>
+            The {pipelineStarted} data pipeline is running in the background.
+            This typically takes a few minutes.
+          </Alert>
+        )}
+
+        {files && (
+          <Paper sx={{ p: 4 }} elevation={1}>
+            <Stack spacing={2}>
+              <Typography variant="h6">IPEDS File Availability</Typography>
+              {files.map(({ file, label, available }) => (
+                <Stack
+                  key={file}
+                  direction="row"
+                  spacing={2}
+                  alignItems="center"
+                  sx={{ py: 0.5 }}
+                >
+                  {available ? (
+                    <CheckCircleIcon color="success" fontSize="small" />
+                  ) : (
+                    <ErrorIcon color="error" fontSize="small" />
+                  )}
+                  <Stack sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Typography variant="body2" fontWeight="medium">
+                      {file}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {label}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              ))}
+
+              {missingCount > 0 && (
+                <Alert severity="warning" sx={{ mt: 1 }}>
+                  {missingCount} file(s) not yet available on IPEDS. The
+                  pipeline cannot run until all files are published.
+                </Alert>
+              )}
+
+              {allAvailable && (
+                <Alert severity="success" sx={{ mt: 1 }}>
+                  All files are available. Ready to run the pipeline.
+                </Alert>
+              )}
+            </Stack>
+          </Paper>
+        )}
       </Stack>
 
       <SubmitButton
         submittingState={submittingState}
         submitChanges={submitChanges}
-        disabled={!year}
+        disabled={!allAvailable}
       />
     </Container>
   );

--- a/src/app/api/admin/check-ipeds-files/route.ts
+++ b/src/app/api/admin/check-ipeds-files/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { getIpedsFilesForYear } from "@/pipeline/utils/ipedsFiles";
+
+const IPEDS_BASE_URL = "https://nces.ed.gov/ipeds/datacenter/data/";
+
+const getNetTicks = () => {
+  return Math.floor((Date.now() / 1000 + 62135596800) * 10000000);
+};
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const year = parseInt(searchParams.get("year") || "", 10);
+
+    if (!year || Number.isNaN(year)) {
+      throw new Error("Specify year in query parameter");
+    }
+
+    const files = getIpedsFilesForYear(year);
+
+    // Deduplicate file names (multiple templates can resolve to the same file
+    // across different year ranges, but each zip only needs to be checked once)
+    const uniqueFiles = [...new Map(files.map((f) => [f.file, f])).values()];
+
+    // Check availability of each file — try static URL, then data generator
+    const results = await Promise.all(
+      uniqueFiles.map(async ({ file, label }) => {
+        // Try static URL first
+        const staticUrl = new URL(file, IPEDS_BASE_URL).href;
+        try {
+          const rsp = await fetch(staticUrl, { method: "HEAD" });
+          if (rsp.ok) return { file, label, available: true };
+        } catch {
+          // fall through
+        }
+
+        // Try data generator fallback (must use GET — HEAD returns 500)
+        const tableName = file.replace(/\.zip$/i, "");
+        const t = getNetTicks();
+        const fallbackUrl = `https://nces.ed.gov/ipeds/data-generator?year=${year}&tableName=${tableName}&HasRV=0&type=csv&t=${t}`;
+        try {
+          const controller = new AbortController();
+          const rsp = await fetch(fallbackUrl, { method: "GET", signal: controller.signal });
+          controller.abort(); // Don't download the full body
+          if (rsp.ok) return { file, label, available: true };
+        } catch (e) {
+          if (e instanceof DOMException && e.name === "AbortError") {
+            return { file, label, available: true };
+          }
+          // fall through
+        }
+
+        return { file, label, available: false };
+      }),
+    );
+
+    return NextResponse.json({
+      year,
+      files: results,
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(null, {
+      status: 400,
+      statusText: "Bad request",
+    });
+  }
+}

--- a/src/app/api/admin/run-data-pipeline/route.ts
+++ b/src/app/api/admin/run-data-pipeline/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 import { pipeline } from "@/pipeline";
 import { revalidateSchools } from "@/cache";
+
+export const maxDuration = 300;
 
 export async function POST(request: Request) {
   try {
@@ -12,8 +15,9 @@ export async function POST(request: Request) {
       throw new Error("Specify year in query parameter");
     }
 
-    // Do not await this promise so that it runs in the background
-    pipeline({ year }).then(() => revalidateSchools());
+    // Use waitUntil to keep the serverless function alive while the
+    // pipeline runs in the background after the response is sent.
+    waitUntil(pipeline({ year }).then(() => revalidateSchools()));
 
     return NextResponse.json({
       message: "Success",

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -10,8 +10,15 @@ import { parseEFFY } from "./parsing/effy";
 import { parseGR } from "./parsing/gr";
 import { parseEFD } from "./parsing/efd";
 import { parseICAY } from "./parsing/icay";
-import { parseSFA } from "./parsing/sfa";
+import { parseSFA, type RowSFA } from "./parsing/sfa";
 import { synthesize } from "./parsing/synthesize";
+
+/**
+ * Starting with 2024, IPEDS reorganised sticker price and net price data
+ * into new COST1 / COST2 files (the column names are unchanged). For older
+ * years the legacy IC_AY and SFA files are still used.
+ */
+const COST_TRANSITION_YEAR = 2024;
 
 /**
   * This function runs the data pipeline for a specific year. It pulls bulk
@@ -37,6 +44,7 @@ export const pipeline = async ({
     registerError,
   };
 
+  console.log(`Starting data pipeline for year ${year}...`);
   console.log("Fetching and parsing data files...");
   performance.mark("fetch-start");
   const [
@@ -71,19 +79,46 @@ export const pipeline = async ({
       parseSchoolRows: parseEFD,
     }, parsingContext),
     parseIpedsFile({
-      file: "IC{YEAR}_AY",
+      file: year >= COST_TRANSITION_YEAR
+        ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST1_{YEAR}" : "IC{YEAR}_AY"
+        : "IC{YEAR}_AY",
       years: 11,
       parseSchoolRows: parseICAY,
     }, parsingContext),
     parseIpedsFile({
-      file: "SFA{ACADEMIC_YEAR}",
+      file: year >= COST_TRANSITION_YEAR
+        ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST2_{YEAR}" : "SFA{ACADEMIC_YEAR}"
+        : "SFA{ACADEMIC_YEAR}",
       years: 11,
       parseSchoolRows: parseSFA,
     }, parsingContext),
   ]);
   performance.mark("fetch-end");
+  console.log(`  HD: ${hd.size} schools, ADM: ${adm.size}, GR: ${gr.size}, EFFY: ${effy.size}, EFD: ${efd.size}`);
+  console.log(`  Sticker price: ${icay.size} schools, Net price: ${sfa.size} schools`);
 
-  console.log("Synthesizing schools...");
+  // For 2024+, UAGRNTP (percent paying sticker price) is still in SFA but
+  // net price data moved to COST2. Fetch the current year's SFA separately
+  // to patch percentSticker into the COST2-based results.
+  if (year >= COST_TRANSITION_YEAR) {
+    const sfaForUagrntp = await parseIpedsFile<RowSFA, { percentSticker: number }>({
+      file: "SFA{ACADEMIC_YEAR}",
+      years: 1,
+      parseSchoolRows: (years) => {
+        const [[row]] = years;
+        return { percentSticker: (100 - (row.UAGRNTP ?? 0)) / 100 };
+      },
+    }, parsingContext);
+
+    for (const [id, { percentSticker }] of sfaForUagrntp) {
+      const sfaData = sfa.get(id);
+      if (sfaData) {
+        sfaData.percentSticker = percentSticker;
+      }
+    }
+  }
+
+  console.log(`Synthesizing ${hd.size} schools...`);
   performance.mark("synthesize-start");
   const schools = [...hd.keys()].map((id) => {
     const school = {
@@ -99,8 +134,9 @@ export const pipeline = async ({
     return synthSchool || undefined;
   }).filter(isNotUndefined);
   performance.mark("synthesize-end");
+  console.log(`Synthesized ${schools.length} schools (${hd.size - schools.length} filtered out)`);
 
-  console.log("Loading schools...");
+  console.log(`Loading ${schools.length} schools into database...`);
   performance.mark("load-start");
   await loadSchools({ schools });
   performance.mark("load-end");
@@ -116,7 +152,20 @@ export const pipeline = async ({
   const measure = (tag: string) => {
     return performance.measure(tag, `${tag}-start`, `${tag}-end`);
   };
-  console.log(measure("fetch"));
-  console.log(measure("synthesize"));
-  console.log(measure("load"));
+  const fmt = (tag: string) => {
+    const m = measure(tag);
+    return `${tag}: ${(m.duration / 1000).toFixed(1)}s`;
+  };
+  console.log(`Timing — ${fmt("fetch")}, ${fmt("synthesize")}, ${fmt("load")}, ${fmt("national-averages")}`);
+  if (errors.length > 0) {
+    const counts = new Map<string, number>();
+    for (const e of errors) {
+      const msg = typeof e === "object" && e !== null && "error" in e ? `${(e as { error: unknown }).error}` : `${e}`;
+      counts.set(msg, (counts.get(msg) ?? 0) + 1);
+    }
+    console.warn(`Pipeline completed with ${errors.length} warning(s):`);
+    for (const [msg, count] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.warn(`  ${count}× ${msg}`);
+    }
+  }
 };

--- a/src/pipeline/parsing/sfa.ts
+++ b/src/pipeline/parsing/sfa.ts
@@ -1,7 +1,7 @@
 import type { ParseContext } from "../utils/parseIpedsFile";
 
 export type RowSFA = {
-  UAGRNTP: number; // percent paying less than sticker price (0 - 100)
+  UAGRNTP?: number; // percent paying less than sticker price (0 - 100); missing in COST2 files (2024+)
   NPIST2: number; // average on-campus net price
   NPGRN2: number; // average off-campus net price
   NPIS412: number; // the rest are on-campus, off-campus net for income brackets
@@ -21,7 +21,9 @@ export const parseSFA = (
   { year: baseYear }: ParseContext,
 ) => {
   const [[mostRecentYear]] = years;
-  const percentSticker = (100 - mostRecentYear.UAGRNTP) / 100;
+  const percentSticker = mostRecentYear.UAGRNTP != null
+    ? (100 - mostRecentYear.UAGRNTP) / 100
+    : null;
 
   const getNetPriceYear = (year: RowSFA, yearNumber: number) => {
     return {

--- a/src/pipeline/utils/fetchAndUnzipIpeds.ts
+++ b/src/pipeline/utils/fetchAndUnzipIpeds.ts
@@ -2,24 +2,52 @@ import AdmZip from "adm-zip";
 import { fetchWithRetries } from "./fetchWithRetries";
 
 /**
+ * Generate a .NET ticks timestamp for use with the IPEDS data generator API.
+ */
+const getNetTicks = () => {
+  return Math.floor((Date.now() / 1000 + 62135596800) * 10000000);
+};
+
+/**
  * Download and unzip a bulk data file from IPEDS. Note that the zip files
  * can contain multiple entries when the data has been revised. We prefer
  * the revised data by looking for entries that end in the suffix `_rv`. If
  * the data hasn't been revised, we just use what we get.
+ *
+ * If the file is not available at the static URL, we fall back to the IPEDS
+ * data generator API, which has some files not yet on the static directory.
  */
 export const fetchAndUnzipIpeds = async ({
   file,
   baseUrl,
+  surveyYear,
 }: {
   file: string;
   baseUrl: string;
+  surveyYear?: number;
 }) => {
   try {
-    const zipUrl = new URL(file, baseUrl).href;
+    const zipBuffer = await (async () => {
+      // Try the static IPEDS directory first
+      const zipUrl = new URL(file, baseUrl).href;
+      try {
+        const rsp = await fetchWithRetries(zipUrl, 1);
+        console.log(`  Downloaded ${file} from static URL`);
+        return Buffer.from(await rsp.arrayBuffer());
+      } catch {
+        // Fall back to the IPEDS data generator API
+        if (!surveyYear) throw new Error(`File not available: ${file}`);
+        const tableName = file.replace(/\.zip$/i, "");
+        const t = getNetTicks();
+        const fallbackUrl = `https://nces.ed.gov/ipeds/data-generator?year=${surveyYear}&tableName=${tableName}&HasRV=0&type=csv&t=${t}`;
+        console.log(`  Static URL not available for ${file}, trying data generator...`);
+        const rsp = await fetchWithRetries(fallbackUrl);
+        console.log(`  Downloaded ${file} from data generator`);
+        return Buffer.from(await rsp.arrayBuffer());
+      }
+    })();
 
-    const rsp = await fetchWithRetries(zipUrl);
-    const body = await rsp.arrayBuffer();
-    const zip = new AdmZip(Buffer.from(body));
+    const zip = new AdmZip(zipBuffer);
     const [unzippedFile] = zip.getEntries()
       .sort((a, b) => {
         const aVal = a.name.includes("_rv") ? 1 : 0;

--- a/src/pipeline/utils/fetchIpedsFile.ts
+++ b/src/pipeline/utils/fetchIpedsFile.ts
@@ -29,6 +29,7 @@ export const fetchIpedsFile = async <FileRow = unknown>({
     fetchAndUnzipIpeds({
       file: `${fileType}.zip`,
       baseUrl,
+      surveyYear: year,
     }),
   ]);
 

--- a/src/pipeline/utils/getNationalAverages.ts
+++ b/src/pipeline/utils/getNationalAverages.ts
@@ -59,7 +59,8 @@ export const getNationalAverages = (schools: Record<string, unknown>[]) => {
   ) => {
     const value = get(school, valuePath);
     if (typeof value === "undefined") return;
-    const degreeLevel = get(school, "degreeLevel") as string;
+    const degreeLevel = get(school, "degreeLevel") as string | null;
+    if (!degreeLevel) return;
     const avg = get(averages, [degreeLevel, avgPath]);
     if (!avg) {
       throw new Error(`Invalid average path: ${degreeLevel}.${avgPath}`);

--- a/src/pipeline/utils/ipedsFiles.ts
+++ b/src/pipeline/utils/ipedsFiles.ts
@@ -1,0 +1,57 @@
+import { resolveFileTemplate } from "./resolveFileTemplate";
+
+/**
+ * Starting with 2024, IPEDS reorganised sticker price and net price data
+ * into new COST1 / COST2 files. For older years the legacy IC_AY and SFA
+ * files are still used. The column names are unchanged.
+ */
+const COST_TRANSITION_YEAR = 2024;
+
+/**
+ * Get all resolved zip file names that the pipeline needs for a given year.
+ * For years >= 2024 this accounts for the IC_AY → COST1 and SFA → COST2
+ * transition, and includes the extra SFA fetch needed for UAGRNTP.
+ */
+export const getIpedsFilesForYear = (year: number) => {
+  const files: { file: string; label: string }[] = [];
+
+  // Standard templates (unchanged across the transition)
+  const standardTemplates = [
+    { template: "HD{YEAR}", years: 1, label: "Institutional Characteristics" },
+    { template: "ADM{YEAR}", years: 1, label: "Admissions" },
+    { template: "GR{YEAR}", years: 5, label: "Graduation Rates" },
+    { template: "EFFY{YEAR}", years: 1, label: "Enrollment" },
+    { template: "EF{YEAR}D", years: 5, label: "Fall Enrollment" },
+  ];
+
+  for (const { template, years, label } of standardTemplates) {
+    for (let i = 0; i < years; i++) {
+      const { fileType } = resolveFileTemplate({ template, year: year - i });
+      files.push({ file: `${fileType}.zip`, label });
+    }
+  }
+
+  // Sticker price: COST1 for years >= 2024, IC_AY for older
+  for (let i = 0; i < 11; i++) {
+    const y = year - i;
+    const template = y >= COST_TRANSITION_YEAR ? "COST1_{YEAR}" : "IC{YEAR}_AY";
+    const { fileType } = resolveFileTemplate({ template, year: y });
+    files.push({ file: `${fileType}.zip`, label: "Sticker Price" });
+  }
+
+  // Net price: COST2 for years >= 2024, SFA for older
+  for (let i = 0; i < 11; i++) {
+    const y = year - i;
+    const template = y >= COST_TRANSITION_YEAR ? "COST2_{YEAR}" : "SFA{ACADEMIC_YEAR}";
+    const { fileType } = resolveFileTemplate({ template, year: y });
+    files.push({ file: `${fileType}.zip`, label: "Net Price" });
+  }
+
+  // For 2024+, also need SFA for the current year to get UAGRNTP
+  if (year >= COST_TRANSITION_YEAR) {
+    const { fileType } = resolveFileTemplate({ template: "SFA{ACADEMIC_YEAR}", year });
+    files.push({ file: `${fileType}.zip`, label: "Net Price (% Sticker)" });
+  }
+
+  return files;
+};

--- a/src/pipeline/utils/loadNationalAverages.ts
+++ b/src/pipeline/utils/loadNationalAverages.ts
@@ -1,7 +1,6 @@
 import { run } from "@/db/pool";
 
 export const loadNationalAverages = async (nationalAverages: Record<string, Record<string, number>>) => {
-  await run("TRUNCATE TABLE national_averages;");
   const rows = Object.entries(nationalAverages).map(([control, avgs]) => {
     return Object.entries(avgs).map(([key, value]) => ({
       schoolControl: control,
@@ -13,12 +12,23 @@ export const loadNationalAverages = async (nationalAverages: Record<string, Reco
     const x = i * 3;
     return `($${x + 1}, $${x + 2}, $${x + 3})`;
   }).join(", ");
-  await run({
-    text: `
-      INSERT INTO national_averages
-        (school_control, average_key, value)
-      VALUES ${valueIds};
-    `,
-    values: rows.map((r) => [r.schoolControl, r.averageKey, r.value]).flat(),
-  });
+
+  // Wrap in a transaction so that if the INSERT fails, the
+  // TRUNCATE is rolled back and existing data is preserved.
+  await run("BEGIN;");
+  try {
+    await run("TRUNCATE TABLE national_averages;");
+    await run({
+      text: `
+        INSERT INTO national_averages
+          (school_control, average_key, value)
+        VALUES ${valueIds};
+      `,
+      values: rows.map((r) => [r.schoolControl, r.averageKey, r.value]).flat(),
+    });
+    await run("COMMIT;");
+  } catch (error) {
+    await run("ROLLBACK;");
+    throw error;
+  }
 };

--- a/src/pipeline/utils/loadSchoolTable.ts
+++ b/src/pipeline/utils/loadSchoolTable.ts
@@ -4,7 +4,6 @@ import { run } from "@/db/pool";
 const schoolColumns = {
   id: "id", 
   slug: "slug",
-  image: "image", 
   name: "name", 
   alias: "alias", 
   city: "city", 
@@ -67,6 +66,7 @@ export const loadSchoolTable = async <School = Record<string, unknown>>(schools:
 
   const valueIdSets = valueIds.map((v) => v.join(", ")).map((v) => `(${v})`).join(", ");
   const updateColumns = Object.keys(schoolColumns)
+    .filter((c) => c !== "id")
     .map((c) => `${c} = EXCLUDED.${c}`)
     .join(", ");
   const query = {

--- a/src/pipeline/utils/parseCsv.ts
+++ b/src/pipeline/utils/parseCsv.ts
@@ -10,6 +10,7 @@ export const parseCsv = async <T = unknown>(text: string) => {
         header: true,
         skipEmptyLines: true,
         dynamicTyping: true,
+        transform: (value) => value === "." ? "" : value,
         complete: (results) => {
           resolve(results);
         },

--- a/src/pipeline/utils/parseIpedsFile.ts
+++ b/src/pipeline/utils/parseIpedsFile.ts
@@ -14,7 +14,7 @@ export type ParseContext = {
 };
 
 export type IpedsFullFileConfig<FileRow = unknown> = {
-  file: string;
+  file: string | ((year: number) => string);
   year: number;
   baseUrl: string;
   parseSchoolRows: (years: FileRow[][], context: ParseContext) => Record<string, unknown>;
@@ -33,7 +33,7 @@ export type IpedsFileConfig<FileRow = unknown> = Pick<
  */
 export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
   config: {
-    file: string;
+    file: string | ((year: number) => string);
     years?: number;
     schoolIdKey?: string;
     parseSchoolRows: (years: FileRow[][], context: ParseContext) => SchoolDataSegment;
@@ -65,8 +65,9 @@ export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
   await [...Array(years)].reduce(async (promise, _, i) => {
     await promise;
 
+    const fileTemplate = typeof file === 'function' ? file(year - i) : file;
     const data = await fetchIpedsFile<FileRow>({
-      fileTemplate: file,
+      fileTemplate,
       year: year - i,
       baseUrl,
     });
@@ -86,7 +87,7 @@ export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
       year,
       registerError: (error) => registerError({
         schoolId,
-        file,
+        file: typeof file === 'function' ? file(year) : file,
         error,
       }),
     });


### PR DESCRIPTION
## Description ##

The data pipeline never completed on Vercel because serverless functions were killed before it finished. This PR fixes that and adds support for the 2024 IPEDS file restructuring.

## Changes ##

**Pipeline fixes**
- Add waitUntil from @vercel/functions so the pipeline runs after the response is sent
- Set maxDuration = 300 for Vercel Pro
- Remove image/image_credit from upsert to prevent nullifying existing school images
- Wrap national averages TRUNCATE+INSERT in a transaction
- Skip schools with null degreeLevel in national averages computation
- Handle IPEDS "." (missing data) in CSV parsing

**IPEDS 2024 support**
- IPEDS restructured files for 2024: sticker prices moved from IC{YEAR}_AY → COST1_{YEAR}, net prices from SFA → COST2_{YEAR}
- Year-conditional file template resolution (COST_TRANSITION_YEAR = 2024)
- Fetch UAGRNTP separately from SFA for 2024+ (still there, but net price columns are empty)
- 2-tier download fallback: static IPEDS URL → data-generator API

**Admin dashboard**
- New pre-run file availability check endpoint (check-ipeds-files)
- Redesigned pipeline UI: enter year → verify files → run

**Other**
- Add logging: per-file download, school counts, timing breakdown, grouped error summary
- Fix bootstrap: continue on image failure instead of aborting, add User-Agent for Wikimedia