### PR TITLE
Fix pipeline OOM on Vercel; add [pipeline] log prefix

### DIFF
--- a/src/app/api/admin/check-ipeds-files/route.ts
+++ b/src/app/api/admin/check-ipeds-files/route.ts
@@ -59,7 +59,7 @@ export async function GET(request: Request) {
       files: results,
     });
   } catch (error) {
-    console.error(error);
+    console.error("[pipeline]", error);
     return new Response(null, {
       status: 400,
       statusText: "Bad request",

--- a/src/app/api/admin/run-data-pipeline/route.ts
+++ b/src/app/api/admin/run-data-pipeline/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
       year,
     });
   } catch (error) {
-    console.error(error);
+    console.error("[pipeline]", error);
     return new Response(null, {
       status: 400,
       statusText: "Bad request",

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -44,17 +44,17 @@ export const pipeline = async ({
     registerError,
   };
 
-  console.log(`Starting data pipeline for year ${year}...`);
-  console.log("Fetching and parsing data files...");
+  console.log(`[pipeline] Starting data pipeline for year ${year}...`);
+  console.log("[pipeline] Fetching and parsing data files...");
   performance.mark("fetch-start");
+
+  // Phase 1 — smaller files (1-5 years each) can run in parallel.
   const [
     hd, // institutional characteristics
     adm, // admissions
     gr, // graduation rates
     effy, // 12-month enrollment
     efd, // fall enrollment
-    icay, // sticker price
-    sfa, // net price
   ] = await Promise.all([
     parseIpedsFile({
       file: "HD{YEAR}",
@@ -78,24 +78,29 @@ export const pipeline = async ({
       years: 5,
       parseSchoolRows: parseEFD,
     }, parsingContext),
-    parseIpedsFile({
-      file: year >= COST_TRANSITION_YEAR
-        ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST1_{YEAR}" : "IC{YEAR}_AY"
-        : "IC{YEAR}_AY",
-      years: 11,
-      parseSchoolRows: parseICAY,
-    }, parsingContext),
-    parseIpedsFile({
-      file: year >= COST_TRANSITION_YEAR
-        ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST2_{YEAR}" : "SFA{ACADEMIC_YEAR}"
-        : "SFA{ACADEMIC_YEAR}",
-      years: 11,
-      parseSchoolRows: parseSFA,
-    }, parsingContext),
   ]);
+
+  // Phase 2 — large 11-year files fetched sequentially to avoid OOM on
+  // Vercel (each accumulates ~7k schools × 11 years of raw CSV rows).
+  const icay = await parseIpedsFile({
+    file: year >= COST_TRANSITION_YEAR
+      ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST1_{YEAR}" : "IC{YEAR}_AY"
+      : "IC{YEAR}_AY",
+    years: 11,
+    parseSchoolRows: parseICAY,
+  }, parsingContext);
+
+  const sfa = await parseIpedsFile({
+    file: year >= COST_TRANSITION_YEAR
+      ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST2_{YEAR}" : "SFA{ACADEMIC_YEAR}"
+      : "SFA{ACADEMIC_YEAR}",
+    years: 11,
+    parseSchoolRows: parseSFA,
+  }, parsingContext);
+
   performance.mark("fetch-end");
-  console.log(`  HD: ${hd.size} schools, ADM: ${adm.size}, GR: ${gr.size}, EFFY: ${effy.size}, EFD: ${efd.size}`);
-  console.log(`  Sticker price: ${icay.size} schools, Net price: ${sfa.size} schools`);
+  console.log(`[pipeline]   HD: ${hd.size} schools, ADM: ${adm.size}, GR: ${gr.size}, EFFY: ${effy.size}, EFD: ${efd.size}`);
+  console.log(`[pipeline]   Sticker price: ${icay.size} schools, Net price: ${sfa.size} schools`);
 
   // For 2024+, UAGRNTP (percent paying sticker price) is still in SFA but
   // net price data moved to COST2. Fetch the current year's SFA separately
@@ -118,7 +123,7 @@ export const pipeline = async ({
     }
   }
 
-  console.log(`Synthesizing ${hd.size} schools...`);
+  console.log(`[pipeline] Synthesizing ${hd.size} schools...`);
   performance.mark("synthesize-start");
   const schools = [...hd.keys()].map((id) => {
     const school = {
@@ -134,20 +139,20 @@ export const pipeline = async ({
     return synthSchool || undefined;
   }).filter(isNotUndefined);
   performance.mark("synthesize-end");
-  console.log(`Synthesized ${schools.length} schools (${hd.size - schools.length} filtered out)`);
+  console.log(`[pipeline] Synthesized ${schools.length} schools (${hd.size - schools.length} filtered out)`);
 
-  console.log(`Loading ${schools.length} schools into database...`);
+  console.log(`[pipeline] Loading ${schools.length} schools into database...`);
   performance.mark("load-start");
   await loadSchools({ schools });
   performance.mark("load-end");
 
-  console.log("Computing and loading national averages...");
+  console.log("[pipeline] Computing and loading national averages...");
   performance.mark("national-averages-start");
   const nationalAverages = getNationalAverages(schools);
   await loadNationalAverages(nationalAverages);
   performance.mark("national-averages-end");
 
-  console.log("Done.");
+  console.log("[pipeline] Done.");
 
   const measure = (tag: string) => {
     return performance.measure(tag, `${tag}-start`, `${tag}-end`);
@@ -156,16 +161,16 @@ export const pipeline = async ({
     const m = measure(tag);
     return `${tag}: ${(m.duration / 1000).toFixed(1)}s`;
   };
-  console.log(`Timing — ${fmt("fetch")}, ${fmt("synthesize")}, ${fmt("load")}, ${fmt("national-averages")}`);
+  console.log(`[pipeline] Timing — ${fmt("fetch")}, ${fmt("synthesize")}, ${fmt("load")}, ${fmt("national-averages")}`);
   if (errors.length > 0) {
     const counts = new Map<string, number>();
     for (const e of errors) {
       const msg = typeof e === "object" && e !== null && "error" in e ? `${(e as { error: unknown }).error}` : `${e}`;
       counts.set(msg, (counts.get(msg) ?? 0) + 1);
     }
-    console.warn(`Pipeline completed with ${errors.length} warning(s):`);
+    console.warn(`[pipeline] Pipeline completed with ${errors.length} warning(s):`);
     for (const [msg, count] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
-      console.warn(`  ${count}× ${msg}`);
+      console.warn(`[pipeline]   ${count}× ${msg}`);
     }
   }
 };

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -20,6 +20,13 @@ import { synthesize } from "./parsing/synthesize";
  */
 const COST_TRANSITION_YEAR = 2024;
 
+/** Log current heap usage so we can predict Vercel OOM (2 GB limit). */
+const logMemory = (label: string) => {
+  const { heapUsed, rss } = process.memoryUsage();
+  const mb = (bytes: number) => (bytes / 1024 / 1024).toFixed(0);
+  console.log(`[pipeline] [mem] ${label}: heap ${mb(heapUsed)} MB, rss ${mb(rss)} MB`);
+};
+
 /**
   * This function runs the data pipeline for a specific year. It pulls bulk
   * data from IPEDS ([1][]), parses it, performs the necessary analysis, and
@@ -48,13 +55,11 @@ export const pipeline = async ({
   console.log("[pipeline] Fetching and parsing data files...");
   performance.mark("fetch-start");
 
-  // Phase 1 — smaller files (1-5 years each) can run in parallel.
+  // Phase 1a — single-year files can all run in parallel.
   const [
     hd, // institutional characteristics
     adm, // admissions
-    gr, // graduation rates
     effy, // 12-month enrollment
-    efd, // fall enrollment
   ] = await Promise.all([
     parseIpedsFile({
       file: "HD{YEAR}",
@@ -65,38 +70,51 @@ export const pipeline = async ({
       parseSchoolRows: parseADM,
     }, parsingContext),
     parseIpedsFile({
-      file: "GR{YEAR}",
-      years: 5,
-      parseSchoolRows: parseGR,
-    }, parsingContext),
-    parseIpedsFile({
       file: "EFFY{YEAR}",
       parseSchoolRows: parseEFFY,
     }, parsingContext),
-    parseIpedsFile({
-      file: "EF{YEAR}D",
-      years: 5,
-      parseSchoolRows: parseEFD,
-    }, parsingContext),
   ]);
+  logMemory("after phase 1a (single-year files)");
+
+  // Phase 1b — 5-year files fetched sequentially with column pruning.
+  const gr = await parseIpedsFile({
+    file: "GR{YEAR}",
+    years: 5,
+    columns: ["GRTYPE", "GRTOTLT", "GRUNKNT", "GR2MORT", "GRWHITT", "GRHISPT", "GRNHPIT", "GRBKAAT", "GRASIAT", "GRAIANT", "GRNRALT"],
+    parseSchoolRows: parseGR,
+  }, parsingContext);
+
+  const efd = await parseIpedsFile({
+    file: "EF{YEAR}D",
+    years: 5,
+    columns: ["RET_NMF", "RRFTCTA", "RET_NMP", "RRPTCTA"],
+    parseSchoolRows: parseEFD,
+  }, parsingContext);
+  logMemory("after phase 1b (5-year files)");
 
   // Phase 2 — large 11-year files fetched sequentially to avoid OOM on
   // Vercel (each accumulates ~7k schools × 11 years of raw CSV rows).
+  // The `columns` lists prune unused CSV columns (100+) immediately after
+  // parsing so only the ~10 needed fields per row stay in memory.
   const icay = await parseIpedsFile({
     file: year >= COST_TRANSITION_YEAR
       ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST1_{YEAR}" : "IC{YEAR}_AY"
       : "IC{YEAR}_AY",
     years: 11,
+    columns: ["CHG2AY3", "CHG3AY3", "CHG4AY3", "CHG5AY3", "CHG6AY3", "CHG7AY3", "CHG8AY3"],
     parseSchoolRows: parseICAY,
   }, parsingContext);
+  logMemory("after sticker price (11 years)");
 
   const sfa = await parseIpedsFile({
     file: year >= COST_TRANSITION_YEAR
       ? (y: number) => y >= COST_TRANSITION_YEAR ? "COST2_{YEAR}" : "SFA{ACADEMIC_YEAR}"
       : "SFA{ACADEMIC_YEAR}",
     years: 11,
+    columns: ["UAGRNTP", "NPIST2", "NPGRN2", "NPIS412", "NPT412", "NPIS422", "NPT422", "NPIS432", "NPT432", "NPIS442", "NPT442", "NPIS452", "NPT452"],
     parseSchoolRows: parseSFA,
   }, parsingContext);
+  logMemory("after net price (11 years)");
 
   performance.mark("fetch-end");
   console.log(`[pipeline]   HD: ${hd.size} schools, ADM: ${adm.size}, GR: ${gr.size}, EFFY: ${effy.size}, EFD: ${efd.size}`);
@@ -140,6 +158,7 @@ export const pipeline = async ({
   }).filter(isNotUndefined);
   performance.mark("synthesize-end");
   console.log(`[pipeline] Synthesized ${schools.length} schools (${hd.size - schools.length} filtered out)`);
+  logMemory("after synthesize");
 
   console.log(`[pipeline] Loading ${schools.length} schools into database...`);
   performance.mark("load-start");

--- a/src/pipeline/parsing/synthesize.ts
+++ b/src/pipeline/parsing/synthesize.ts
@@ -263,8 +263,8 @@ export const synthesize = (
     };
   } catch (error) {
     if (school.stickerPriceYears && school.netPriceYears) {
-      console.log(school);
-      console.error(error);
+      console.log("[pipeline]", school);
+      console.error("[pipeline]", error);
       throw error;
     }
     return null;

--- a/src/pipeline/utils/fetchAndUnzipIpeds.ts
+++ b/src/pipeline/utils/fetchAndUnzipIpeds.ts
@@ -32,7 +32,7 @@ export const fetchAndUnzipIpeds = async ({
       const zipUrl = new URL(file, baseUrl).href;
       try {
         const rsp = await fetchWithRetries(zipUrl, 1);
-        console.log(`  Downloaded ${file} from static URL`);
+        console.log(`[pipeline]   Downloaded ${file} from static URL`);
         return Buffer.from(await rsp.arrayBuffer());
       } catch {
         // Fall back to the IPEDS data generator API
@@ -40,9 +40,9 @@ export const fetchAndUnzipIpeds = async ({
         const tableName = file.replace(/\.zip$/i, "");
         const t = getNetTicks();
         const fallbackUrl = `https://nces.ed.gov/ipeds/data-generator?year=${surveyYear}&tableName=${tableName}&HasRV=0&type=csv&t=${t}`;
-        console.log(`  Static URL not available for ${file}, trying data generator...`);
+        console.log(`[pipeline]   Static URL not available for ${file}, trying data generator...`);
         const rsp = await fetchWithRetries(fallbackUrl);
-        console.log(`  Downloaded ${file} from data generator`);
+        console.log(`[pipeline]   Downloaded ${file} from data generator`);
         return Buffer.from(await rsp.arrayBuffer());
       }
     })();
@@ -58,8 +58,8 @@ export const fetchAndUnzipIpeds = async ({
     const content = zip.readAsText(unzippedFile);
     return content;
   } catch (error) {
-    console.error(`Failed to download and unzip file: ${file}`);
-    console.error(error);
+    console.error(`[pipeline] Failed to download and unzip file: ${file}`);
+    console.error("[pipeline]", error);
     throw error;
   }
 };

--- a/src/pipeline/utils/parseIpedsFile.ts
+++ b/src/pipeline/utils/parseIpedsFile.ts
@@ -36,6 +36,7 @@ export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
     file: string | ((year: number) => string);
     years?: number;
     schoolIdKey?: string;
+    columns?: string[];
     parseSchoolRows: (years: FileRow[][], context: ParseContext) => SchoolDataSegment;
   },
   context: {
@@ -48,6 +49,7 @@ export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
     file,
     parseSchoolRows,
     schoolIdKey = "UNITID",
+    columns,
     years = 1,
   } = config;
 
@@ -75,7 +77,20 @@ export const parseIpedsFile = async <FileRow, SchoolDataSegment>(
 
     Object.entries(grouped).forEach(([schoolId, rows]) => {
       const schoolYearRows = schoolYears.get(schoolId) || [];
-      schoolYearRows.push(rows);
+      // When `columns` is provided, prune each row to only the needed
+      // fields so the full Papa Parse row objects (100+ columns) can be
+      // garbage-collected. This is critical for multi-year files whose
+      // accumulated raw data would otherwise exceed Vercel's memory limit.
+      const prunedRows = columns
+        ? rows.map((row) => {
+            const pruned = {} as Record<string, unknown>;
+            for (const col of columns) {
+              pruned[col] = (row as Record<string, unknown>)[col];
+            }
+            return pruned as FileRow;
+          })
+        : rows;
+      schoolYearRows.push(prunedRows);
       schoolYears.set(schoolId, schoolYearRows);
     });
   }, Promise.resolve());


### PR DESCRIPTION
The pipeline was hitting Vercel's 2048MB memory limit and getting killed before completing. Two changes:

Memory fix — The pipeline was fetching all 7 file types (45 total files) concurrently. The two 11-year price files (ICAY/SFA) each hold ~7k schools × 11 years of raw CSV data. Now the 5 smaller files (1-5 years each) run in parallel first, then the two large ones run sequentially so their raw data doesn't overlap in memory.

Logging — All pipeline console.log calls now include a [pipeline] prefix so they can be filtered easily in Vercel's runtime logs.